### PR TITLE
Perform heavy calcs with np array operations

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -157,6 +157,7 @@ class particles:
 
         # calculate differential position vector and kernel gradient
         dx = self.x[pair_i, :] - self.x[pair_j, :]
+        dv = self.v[pair_i, :] - self.v[pair_j, :]
         dwdx = np.apply_along_axis(kernel.dwdx, 1, dx)
 
         for k in range(pair_i.shape[0]):
@@ -164,8 +165,7 @@ class particles:
             j = pair_j[k]
 
             # update acceleration with artificial viscosity
-            dv = self.v[i, :] - self.v[j, :]
-            vr = np.dot(dv[:], dx[k, :])
+            vr = np.dot(dv[k, :], dx[k, :])
             if vr > 0.: vr = 0.
             rr = np.dot(dx[k, :], dx[k, :])
             muv = self.h*vr/(rr + self.h*self.h*0.01)
@@ -186,17 +186,17 @@ class particles:
             dvdt[i, 1] += h
             dvdt[j, 1] -= h
 
-            tmp_drhodt = self.mass*np.dot(self.v[i,:]-self.v[j,:], dwdx[k, :])
+            tmp_drhodt = self.mass*np.dot(dv[k, :], dwdx[k, :])
             drhodt[i] += tmp_drhodt
             drhodt[j] += tmp_drhodt
 
             # calculating engineering strain rates
             he = np.zeros(4, dtype=np.float64)
-            he[0] = -dv[0]*dwdx[k, 0]
-            he[1] = -dv[1]*dwdx[k, 1]
+            he[0] = -dv[k, 0]*dwdx[k, 0]
+            he[1] = -dv[k, 1]*dwdx[k, 1]
             #he[2] = 0.
-            he[3] = -0.5*(dv[0]*dwdx[k, 1]+dv[1]*dwdx[k, 0])
-            hrxy = -0.5*(dv[0]*dwdx[k, 1] - dv[1]*dwdx[k, 0])
+            he[3] = -0.5*(dv[k, 0]*dwdx[k, 1]+dv[k, 1]*dwdx[k, 0])
+            hrxy = -0.5*(dv[k, 0]*dwdx[k, 1] - dv[k, 1]*dwdx[k, 0])
 
             dstraindt[i, 0] += self.mass*he[0]/self.rho[j]
             dstraindt[i, 1] += self.mass*he[1]/self.rho[j]

--- a/classes.py
+++ b/classes.py
@@ -111,14 +111,15 @@ class particles:
             if pair_i.shape[0] > 0:
                 r = np.linalg.norm(self.x[pair_i, :] - self.x[pair_j, :], axis=1)
                 w = np.apply_along_axis(kernel.w, 0, r)
-                np.add.at(vw, pair_i, w[:]*self.mass/self.rho[pair_j])
-                np.subtract.at(self.v[:, 0], pair_i, self.mass*self.v[pair_j, 0]/self.rho[pair_j]*w)
-                np.subtract.at(self.v[:, 1], pair_i, self.mass*self.v[pair_j, 1]/self.rho[pair_j]*w)
+                dvol = self.mass/self.rho[pair_j]
+                np.add.at(vw, pair_i, w[:]*dvol[:])
+                np.subtract.at(self.v[:, 0], pair_i, self.v[pair_j, 0]*w*dvol[:])
+                np.subtract.at(self.v[:, 1], pair_i, self.v[pair_j, 1]*w*dvol[:])
                 np.add.at(self.rho, pair_i, self.mass*w)
-                np.add.at(self.sigma[:, 0], pair_i, self.sigma[pair_j, 0]*self.mass/self.rho[pair_j]*w)
-                np.add.at(self.sigma[:, 1], pair_i, self.sigma[pair_j, 1]*self.mass/self.rho[pair_j]*w)
-                np.add.at(self.sigma[:, 2], pair_i, self.sigma[pair_j, 2]*self.mass/self.rho[pair_j]*w)
-                np.add.at(self.sigma[:, 3], pair_i, self.sigma[pair_j, 3]*self.mass/self.rho[pair_j]*w)
+                np.add.at(self.sigma[:, 0], pair_i, self.sigma[pair_j, 0]*w*dvol[:])
+                np.add.at(self.sigma[:, 1], pair_i, self.sigma[pair_j, 1]*w*dvol[:])
+                np.add.at(self.sigma[:, 2], pair_i, self.sigma[pair_j, 2]*w*dvol[:])
+                np.add.at(self.sigma[:, 3], pair_i, self.sigma[pair_j, 3]*w*dvol[:])
 
         # sweep over all pairs and update virtual particles' properties
         # only consider real-virtual pairs
@@ -141,14 +142,15 @@ class particles:
         update_virti(pair_j, pair_i)
 
         # normalize virtual particle properties with summed kernels
-        self.v[self.ntotal:self.ntotal+self.nvirt, 0] = np.divide(self.v[self.ntotal:self.ntotal+self.nvirt, 0], vw[self.ntotal:self.ntotal+self.nvirt], where=(vw[self.ntotal:self.ntotal+self.nvirt]>0.) )
-        self.v[self.ntotal:self.ntotal+self.nvirt, 1] = np.divide(self.v[self.ntotal:self.ntotal+self.nvirt, 1], vw[self.ntotal:self.ntotal+self.nvirt], where=(vw[self.ntotal:self.ntotal+self.nvirt]>0.) )
-        self.sigma[self.ntotal:self.ntotal+self.nvirt, 0] = np.divide(self.sigma[self.ntotal:self.ntotal+self.nvirt, 0], vw[self.ntotal:self.ntotal+self.nvirt], where=(vw[self.ntotal:self.ntotal+self.nvirt]>0.) )
-        self.sigma[self.ntotal:self.ntotal+self.nvirt, 1] = np.divide(self.sigma[self.ntotal:self.ntotal+self.nvirt, 1], vw[self.ntotal:self.ntotal+self.nvirt], where=(vw[self.ntotal:self.ntotal+self.nvirt]>0.) )
-        self.sigma[self.ntotal:self.ntotal+self.nvirt, 2] = np.divide(self.sigma[self.ntotal:self.ntotal+self.nvirt, 2], vw[self.ntotal:self.ntotal+self.nvirt], where=(vw[self.ntotal:self.ntotal+self.nvirt]>0.) )
-        self.sigma[self.ntotal:self.ntotal+self.nvirt, 3] = np.divide(self.sigma[self.ntotal:self.ntotal+self.nvirt, 3], vw[self.ntotal:self.ntotal+self.nvirt], where=(vw[self.ntotal:self.ntotal+self.nvirt]>0.) )
-        self.rho[self.ntotal:self.ntotal+self.nvirt] = np.divide(self.rho[self.ntotal:self.ntotal+self.nvirt], vw[self.ntotal:self.ntotal+self.nvirt], where=(vw[self.ntotal:self.ntotal+self.nvirt]>0.) )
-        self.rho[self.ntotal:self.ntotal+self.nvirt] = np.where((vw[self.ntotal:self.ntotal+self.nvirt]>0.), self.rho[self.ntotal:self.ntotal+self.nvirt], self.rho_ini)
+        vw_mask = vw[self.ntotal:self.ntotal+self.nvirt]>0.
+        self.v[self.ntotal:self.ntotal+self.nvirt, 0] = np.divide(self.v[self.ntotal:self.ntotal+self.nvirt, 0], vw[self.ntotal:self.ntotal+self.nvirt], where=vw_mask)
+        self.v[self.ntotal:self.ntotal+self.nvirt, 1] = np.divide(self.v[self.ntotal:self.ntotal+self.nvirt, 1], vw[self.ntotal:self.ntotal+self.nvirt], where=vw_mask)
+        self.sigma[self.ntotal:self.ntotal+self.nvirt, 0] = np.divide(self.sigma[self.ntotal:self.ntotal+self.nvirt, 0], vw[self.ntotal:self.ntotal+self.nvirt], where=vw_mask)
+        self.sigma[self.ntotal:self.ntotal+self.nvirt, 1] = np.divide(self.sigma[self.ntotal:self.ntotal+self.nvirt, 1], vw[self.ntotal:self.ntotal+self.nvirt], where=vw_mask)
+        self.sigma[self.ntotal:self.ntotal+self.nvirt, 2] = np.divide(self.sigma[self.ntotal:self.ntotal+self.nvirt, 2], vw[self.ntotal:self.ntotal+self.nvirt], where=vw_mask)
+        self.sigma[self.ntotal:self.ntotal+self.nvirt, 3] = np.divide(self.sigma[self.ntotal:self.ntotal+self.nvirt, 3], vw[self.ntotal:self.ntotal+self.nvirt], where=vw_mask)
+        self.rho[self.ntotal:self.ntotal+self.nvirt] = np.divide(self.rho[self.ntotal:self.ntotal+self.nvirt], vw[self.ntotal:self.ntotal+self.nvirt], where=vw_mask)
+        self.rho[self.ntotal:self.ntotal+self.nvirt] = np.where(vw_mask, self.rho[self.ntotal:self.ntotal+self.nvirt], self.rho_ini)
 
     # function to perform sweep over all particle pairs
     def pair_sweep(self, 

--- a/classes.py
+++ b/classes.py
@@ -158,7 +158,8 @@ class particles:
         # calculate differential position vector and kernel gradient
         dx = self.x[pair_i, :] - self.x[pair_j, :]
         dv = self.v[pair_i, :] - self.v[pair_j, :]
-        dwdx = np.apply_along_axis(kernel.dwdx, 1, dx)
+        # dwdx = np.apply_along_axis(kernel.dwdx, 1, dx)
+        dwdx = kernel.dwdx(dx)
 
         # update acceleration with artificial viscosity
         vr = np.einsum("ij,ij->i", dv, dx)

--- a/classes.py
+++ b/classes.py
@@ -188,13 +188,19 @@ class particles:
         np.subtract.at(dvdt[:, 0], pair_j, h[:, 0])
         np.subtract.at(dvdt[:, 1], pair_j, h[:, 1])
 
+        # update density change rate with continuity density
+        drhodt_pairs = self.mass*np.einsum("ij,ij->i", dv, dwdx)
+
+        np.add.at(drhodt, pair_i, drhodt_pairs)
+        np.add.at(drhodt, pair_j, drhodt_pairs)
+
         for k in range(pair_i.shape[0]):
             i = pair_i[k]
             j = pair_j[k]
 
-            tmp_drhodt = self.mass*np.dot(dv[k, :], dwdx[k, :])
-            drhodt[i] += tmp_drhodt
-            drhodt[j] += tmp_drhodt
+            # tmp_drhodt = self.mass*np.dot(dv[k, :], dwdx[k, :])
+            # drhodt[i] += tmp_drhodt
+            # drhodt[j] += tmp_drhodt
 
             # calculating engineering strain rates
             he = np.zeros(4, dtype=np.float64)

--- a/classes.py
+++ b/classes.py
@@ -50,7 +50,6 @@ class particles:
         dsig[:, 3] += sigma0[0:self.ntotal, 0]*drxy[0:self.ntotal] - sigma0[0:self.ntotal, 1]*drxy[0:self.ntotal]
 
         # update stress state
-        # self.sigma[i, :] = sigma0[:] + dsig[:]
         self.sigma[0:self.ntotal] = sigma0[0:self.ntotal, :] + dsig[:, :]
 
         # define identity and D2 matrisices (Voigt notation)

--- a/classes.py
+++ b/classes.py
@@ -327,9 +327,9 @@ class integrators:
             sigma0 = np.copy(pts.sigma[0:pts.ntotal+pts.nvirt, :])
 
             # Update data to mid-timestep
-            for i in range(pts.ntotal):
-                pts.rho[i] += 0.5*dt*drhodt[i]
-                pts.v[i, :] += 0.5*dt*dvdt[i, :]
+            pts.rho[0:pts.ntotal] += 0.5*dt*drhodt[0:pts.ntotal]
+            pts.v[0:pts.ntotal, :] += 0.5*dt*dvdt[0:pts.ntotal, :]
+
             pts.stress_update(0.5*dt*dstraindt, 0.5*dt*rxy, sigma0)
 
             # initialize material rate arrays
@@ -344,12 +344,10 @@ class integrators:
             pts.stress_update(dt*dstraindt, dt*rxy, sigma0)
 
             # update data to full-timestep
-            for i in range(pts.ntotal):
-                pts.rho[i] = rho0[i] + dt*drhodt[i]
-                pts.v[i, :] = v0[i, :] + dt*dvdt[i, :]
-                pts.x[i, :] += dt*pts.v[i, :]
-                # pts.stress_update(i, dt*dstraindt[i, :], dt*rxy[i], sigma0[i, :])
-                pts.strain[i, :] += dt*dstraindt[i, :]
+            pts.rho[0:pts.ntotal] = rho0[0:pts.ntotal] + dt*drhodt[0:pts.ntotal]
+            pts.v[0:pts.ntotal, :] = v0[0:pts.ntotal, :] + dt*dvdt[0:pts.ntotal, :]
+            pts.x[0:pts.ntotal, :] += dt*pts.v[0:pts.ntotal, :]
+            pts.strain[0:pts.ntotal, :] += dt*dstraindt[0:pts.ntotal, :]
 
             # print data to terminal if needed
             if itimestep % self.printtimestep == 0:

--- a/classes.py
+++ b/classes.py
@@ -117,14 +117,16 @@ class particles:
             where=np.repeat(f_mask[:, np.newaxis], 4, 1)
         )
 
-        for i in range(ntotal):
-
-            # tensile cracking check 2:
-            # corrected stress state is outside yield surface
-            I1[i] = sigma[i, 0] + sigma[i, 1] + sigma[i, 2]
-            if I1[i] > k_c/alpha_phi:
-                sigma[i, 0:3] = k_c/alpha_phi/3
-                sigma[i, 3] = 0.
+        ## tensile cracking check 2:
+        # corrected stress state is outside yield surface
+        I1 = np.sum(sigma[0:ntotal, 0:3], axis=1)
+        tensile_crack_check2_mask = I1 > k_c/alpha_phi
+        sigma[0:ntotal, 0:3] = np.where(
+            np.repeat(tensile_crack_check2_mask[:, np.newaxis], 3, 1),
+            k_c/alpha_phi/3, 
+            sigma[0:ntotal, 0:3]
+        )
+        sigma[0:ntotal, 3] = np.where(tensile_crack_check2_mask, 0., sigma[0:ntotal, 3])
 
         # simple fluid equation of state.
         # for i in range(self.ntotal+self.nvirt):

--- a/classes.py
+++ b/classes.py
@@ -99,22 +99,14 @@ class particles:
         tree = sp.spatial.cKDTree(self.x[0:self.ntotal+self.nvirt, :])
         self.pairs = tree.query_pairs(3*self.dx, output_type='set')
 
-    # function to perform sweep over all particle pairs
-    def pair_sweep(self, 
-                   dvdt: np.ndarray, 
-                   drhodt: np.ndarray, 
-                   dstraindt: np.ndarray, 
-                   rxy: np.ndarray,
-                   kernel: typing.Type):
-        
-        ## update virtual particles' properties first --------------------------
+    def update_virtualparticle_properties(self, kernel: typing.Type):
 
         # zeroing virutal particles' properties
         self.v[self.ntotal:self.ntotal+self.nvirt, :].fill(0.)
         self.rho[self.ntotal:self.ntotal+self.nvirt].fill(0.)
         self.sigma[self.ntotal:self.ntotal+self.nvirt, :].fill(0.)
         vw = np.zeros(self.ntotal+self.nvirt, dtype=np.float64)
-        
+
         # sweep over all pairs and update virtual particles' properties
         # only consider real-virtual pairs
         for i, j in self.pairs:
@@ -140,6 +132,17 @@ class particles:
                 self.sigma[i, :] /= vw[i]
             else:
                 self.rho[i] = self.rho_ini
+
+    # function to perform sweep over all particle pairs
+    def pair_sweep(self, 
+                   dvdt: np.ndarray, 
+                   drhodt: np.ndarray, 
+                   dstraindt: np.ndarray, 
+                   rxy: np.ndarray,
+                   kernel: typing.Type):
+        
+        ## update virtual particles' properties first --------------------------
+        self.update_virtualparticle_properties(kernel)
 
         # sweep over all pairs to update real particles' material rates --------
         for i, j in self.pairs:

--- a/kernels.py
+++ b/kernels.py
@@ -9,7 +9,7 @@ class wenland_c2:
         q = r/self.h
         return self.alpha*np.maximum(0., 2.-q)**4*(2.*q+1.)
     def dwdx(self, dx: np.ndarray):
-        r = np.apply_along_axis(np.linalg.norm, 1, dx)
+        r = np.sqrt(np.einsum("ij,ij->i", dx, dx))
         q = r/self.h
         dwdx_coeff = -self.alpha*10.*q[:]*np.maximum(0., 2.-q[:])**3/(r[:]*self.h)
         return np.einsum("i,ij->ij", dwdx_coeff, dx)

--- a/kernels.py
+++ b/kernels.py
@@ -9,6 +9,7 @@ class wenland_c2:
         q = r/self.h
         return self.alpha*max(0., 2.-q)**4*(2.*q+1.)
     def dwdx(self, dx: np.ndarray):
-        r = np.linalg.norm(dx)
+        r = np.apply_along_axis(np.linalg.norm, 1, dx)
         q = r/self.h
-        return -self.alpha*10.*q*max(0., 2.-q)**3*dx[:]/(r*self.h)
+        dwdx_coeff = -self.alpha*10.*q[:]*np.maximum(0., 2.-q[:])**3/(r[:]*self.h)
+        return np.einsum("i,ij->ij", dwdx_coeff, dx)

--- a/kernels.py
+++ b/kernels.py
@@ -5,9 +5,9 @@ class wenland_c2:
         self.k = k
         self.h = h
         self.alpha = 7./(64.*np.pi*self.h*self.h)
-    def w(self, r: float):
+    def w(self, r: np.ndarray):
         q = r/self.h
-        return self.alpha*max(0., 2.-q)**4*(2.*q+1.)
+        return self.alpha*np.maximum(0., 2.-q)**4*(2.*q+1.)
     def dwdx(self, dx: np.ndarray):
         r = np.apply_along_axis(np.linalg.norm, 1, dx)
         q = r/self.h


### PR DESCRIPTION
* update particles' x, v, rho to array opts in `integrators.LF`
* update particles' stress with array opts in `particles.stress_update`
* `particles.findpairs` now emit `pair_i` and `pair_j` (1D) arrays, instead of `pairs` (2D) array.
* `particles.findpairs` performs filtering to remove virtual-virtual interactions
* Virtual particle update moved to seperate function `particles.update_virtualparticle_properties`
* Virtual particle update and `particles.pair_sweep` now use `pair_i` and `pair_j` arrays
* Virtual particle update and `particles.pair_sweep` perform all calculations with array operations