### PR TITLE
Use closefriends instead of scipy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ A Python, and super basic, version of GraSPH. Early stages of development. Only 
 Package requirements:
 
 ```bash
-pip/conda/mamba install scipy h5py 'numpy>=1.25'
+pip install -r requirements.txt
 ```
 
-I recommend using NumPy version at least 1.25 as performance improvements are introduced which
+NumPy version 1.25 is used here as performance improvements are introduced which
 improve speed of this code by 4x. See [NumPy Release Notes](https://numpy.org/doc/stable/release/1.25.0-notes.html#numpy-1-25-0-release-notes),
 where the improvements to `np.ufunc.at` and `np.einsum` are most relevant.
 

--- a/classes.py
+++ b/classes.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy as sp
 import typing
 import h5py
 from closefriends import query_pairs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+h5py
+numpy>=1.25
+git+https://github.com/edoyango/closefriends.git


### PR DESCRIPTION
Use bespoke [closefriends](https://github.com/edoyango/closefriends) package to reduce time spent on finding pairs. Which reduces total runtime by about 10%.